### PR TITLE
remove the boolean which gives the error for sbt test

### DIFF
--- a/src/test/scala/infoflow.scala
+++ b/src/test/scala/infoflow.scala
@@ -9,7 +9,7 @@
 
 class InfoFlowTest extends SparkTestSuite
 {
-  val infoFlow = new InfoFlow("asymmetric",false)
+  val infoFlow = new InfoFlow("asymmetric")
 
   test("Test trivial network") {
     val( codelength, partition, graph, _ )


### PR DESCRIPTION
[error] /home/amila/documents/InfoFlow/src/test/scala/infoflow.scala:12:18: overloaded method constructor InfoFlow with alternatives:
[error]   (config: JsonObj)InfoFlow <and>
[error]   (mergeDirection: String)InfoFlow
[error]  cannot be applied to (String, Boolean)
[error]   val infoFlow = new InfoFlow("asymmetric",false)
[error]                  ^
[error] one error found
[error] (Test / compileIncremental) Compilation failed
